### PR TITLE
Enhance demo with saving output as numpy arrays feature and update README

### DIFF
--- a/IGEV-Stereo/demo_imgs.py
+++ b/IGEV-Stereo/demo_imgs.py
@@ -50,6 +50,8 @@ def demo(args):
             file_stem = imfile1.split('/')[-2]
             filename = os.path.join(output_directory, f"{file_stem}.png")
             plt.imsave(output_directory / f"{file_stem}.png", disp.squeeze(), cmap='jet')
+            if args.save_numpy:
+                np.save(output_directory / f"{file_stem}.npy", disp.squeeze())
             # disp = np.round(disp * 256).astype(np.uint16)
             # cv2.imwrite(filename, cv2.applyColorMap(cv2.convertScaleAbs(disp.squeeze(), alpha=0.01),cv2.COLORMAP_JET), [int(cv2.IMWRITE_PNG_COMPRESSION), 0])
 

--- a/IGEV-Stereo/demo_video.py
+++ b/IGEV-Stereo/demo_video.py
@@ -56,6 +56,8 @@ if __name__ == '__main__':
 
     fps_list = np.array([])
     videoWrite = cv2.VideoWriter('./IGEV_Stereo.mp4', cv2.VideoWriter_fourcc(*'mp4v'), 10, (1242, 750))
+    if args.save_numpy:
+        frames = []  # Save the output frames to numpy arrays 
     for (imfile1, imfile2) in tqdm(list(zip(left_images, right_images))):
         image1 = load_image(imfile1)
         image2 = load_image(imfile2)
@@ -81,6 +83,8 @@ if __name__ == '__main__':
         print('Stereo runtime: {:.3f}'.format(1000/avg_fps))
 
         disp_np = (2*disp).data.cpu().numpy().squeeze().astype(np.uint8)
+        if args.save_numpy:
+            frames.append(out_img)
         disp_np = cv2.applyColorMap(disp_np, cv2.COLORMAP_PLASMA)
         image_np = np.array(Image.open(imfile1)).astype(np.uint8)       
         out_img = np.concatenate((image_np, disp_np), 0)
@@ -93,3 +97,5 @@ if __name__ == '__main__':
         cv2.waitKey(1)
         videoWrite.write(out_img)
     videoWrite.release()
+    if args.save_numpy:
+        np.savez('IGEV_Stereo.npz', *frames)

--- a/IGEV-Stereo/demo_video.py
+++ b/IGEV-Stereo/demo_video.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
 
         disp_np = (2*disp).data.cpu().numpy().squeeze().astype(np.uint8)
         if args.save_numpy:
-            frames.append(out_img)
+            frames.append(disp_np)
         disp_np = cv2.applyColorMap(disp_np, cv2.COLORMAP_PLASMA)
         image_np = np.array(Image.open(imfile1)).astype(np.uint8)       
         out_img = np.concatenate((image_np, disp_np), 0)

--- a/IGEV-Stereo/save_disp.py
+++ b/IGEV-Stereo/save_disp.py
@@ -52,6 +52,8 @@ def demo(args):
             disp = disp.cpu().numpy().squeeze()
             disp = np.round(disp * 256).astype(np.uint16)
             skimage.io.imsave(file_stem, disp)
+            if args.save_numpy:
+                np.save(output_directory / f"{file_stem}.npy", disp.squeeze())
 
 
 if __name__ == '__main__':

--- a/README.md
+++ b/README.md
@@ -14,8 +14,20 @@ We assume the downloaded pretrained weights are located under the pretrained_mod
 
 You can demo a trained model on pairs of images. To predict stereo for Middlebury, run
 ```
-python demo.py --restore_ckpt ./pretrained_models/sceneflow/sceneflow.pth
+python demo_imgs.py \
+--restore_ckpt pretrained_models/sceneflow/sceneflow.pth \
+-l=path/to/your/left_imgs \
+-r=path/to/your/right_imgs
 ```
+or you can demo a trained model pairs of images for a video, run:
+```
+python demo_imgs.py \
+--restore_ckpt pretrained_models/sceneflow/sceneflow.pth \
+-l=path/to/your/left_imgs \
+-r=path/to/your/right_imgs
+```
+
+To save the disparity values as .npy files, run any of the demos with the ```--save_numpy``` flag.
 
 <img src="IGEV-Stereo/demo-imgs.png" width="90%">
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Pretrained models can be downloaded from [google drive](https://drive.google.com
 We assume the downloaded pretrained weights are located under the pretrained_models directory.
 
 You can demo a trained model on pairs of images. To predict stereo for Middlebury, run
-```
+```Shell
 python demo_imgs.py \
 --restore_ckpt pretrained_models/sceneflow/sceneflow.pth \
 -l=path/to/your/left_imgs \
 -r=path/to/your/right_imgs
 ```
 or you can demo a trained model pairs of images for a video, run:
-```
+```Shell
 python demo_imgs.py \
 --restore_ckpt pretrained_models/sceneflow/sceneflow.pth \
 -l=path/to/your/left_imgs \
@@ -46,13 +46,13 @@ To save the disparity values as .npy files, run any of the demos with the ```--s
 
 ### Create a virtual environment and activate it.
 
-```
+```Shell
 conda create -n IGEV_Stereo python=3.8
 conda activate IGEV_Stereo
 ```
 ### Dependencies
 
-```
+```Shell
 conda install pytorch torchvision torchaudio cudatoolkit=11.3 -c pytorch -c nvidia
 pip install opencv-python
 pip install scikit-image


### PR DESCRIPTION
I encountered a minor issue while using the IGEV demo, specifically, the "save numpy" option was not functioning. As a result, I have re-implemented this functionality and added it back in. 
Here are the details:
- Reimplemented the feature to save output as numpy arrays, which allows users to conveniently save output data in .npy or .npz, facilitating subsequent data processing and analysis.
- Added detailed instructions on how to use the demo_imgs.py and demo_video.py .