### PR TITLE
use action="store_true" in IGEV-Stereo/demo_imgs.py

### DIFF
--- a/IGEV-Stereo/demo_imgs.py
+++ b/IGEV-Stereo/demo_imgs.py
@@ -59,7 +59,7 @@ def demo(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--restore_ckpt', help="restore checkpoint", default='./pretrained_models/sceneflow/sceneflow.pth')
-    parser.add_argument('--save_numpy', default=False, help='save output as numpy arrays')
+    parser.add_argument('--save_numpy', action="store_true", help='save output as numpy arrays')
 
     parser.add_argument('-l', '--left_imgs', help="path to all first (left) frames", default="./demo-imgs/*/im0.png")
     parser.add_argument('-r', '--right_imgs', help="path to all second (right) frames", default="./demo-imgs/*/im1.png")


### PR DESCRIPTION
# why
I found that  `--save_numpy` option in IGEV-Stereo/demo_imgs.py is not working as expected.

```
cd IGEV-Stereo
python3 demo_imgs.py --restore_ckpt sceneflow.pth -l=../test_data/left.png  -r=../test_data/right.png --save_numpy
usage: demo_imgs.py [-h] [--restore_ckpt RESTORE_CKPT] [--save_numpy SAVE_NUMPY] [-l LEFT_IMGS] [-r RIGHT_IMGS]
                    [--output_directory OUTPUT_DIRECTORY] [--mixed_precision] [--valid_iters VALID_ITERS]
                    [--hidden_dims HIDDEN_DIMS [HIDDEN_DIMS ...]] [--corr_implementation {reg,alt,reg_cuda,alt_cuda}]
                    [--shared_backbone] [--corr_levels CORR_LEVELS] [--corr_radius CORR_RADIUS] [--n_downsample N_DOWNSAMPLE]
                    [--slow_fast_gru] [--n_gru_layers N_GRU_LAYERS] [--max_disp MAX_DISP]
demo_imgs.py: error: argument --save_numpy: expected one argument

```
# what
I found that the following modification would work as expected:

```
-    parser.add_argument('--save_numpy', default=False, help='save output as numpy arrays')
+    parser.add_argument('--save_numpy', action="store_true", help='save output as numpy arrays')

```
